### PR TITLE
Fix tipsi-stripe dependency

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -24,5 +24,5 @@ project(':react-native-camera').projectDir = new File(rootProject.projectDir, '.
 include ':lottie-react-native'
 project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/lottie-react-native/src/android')
 include ':tipsi-stripe'
-project(':tipsi-stripe').projectDir = new File(rootProject.projectDir, '../node_modules/tipsi-stripe/android')
+project(':tipsi-stripe').projectDir = new File(rootProject.projectDir, '../node_modules/@commaai/tipsi-stripe/android')
 include ':app'

--- a/js/api/stripe.js
+++ b/js/api/stripe.js
@@ -1,4 +1,4 @@
-import stripe from 'tipsi-stripe';
+import stripe from '@commaai/tipsi-stripe';
 let STRIPE_PUBLISHABLE_KEY;
 if (__DEV__) {
   STRIPE_PUBLISHABLE_KEY = 'pk_test_jn26O6Fvi063fJIM1z7xuydB';

--- a/js/components/PrimePayment/PrimePayment.js
+++ b/js/components/PrimePayment/PrimePayment.js
@@ -3,7 +3,7 @@ import { Keyboard, TouchableWithoutFeedback, View, Platform } from 'react-native
 import { withNavigation } from 'react-navigation';
 import { LiteCreditCardInput } from "react-native-credit-card-input";
 import CardIcons from "react-native-credit-card-input/src/Icons";
-import stripe from 'tipsi-stripe';
+import stripe from '@commaai/tipsi-stripe';
 
 import { Assets } from '../../constants';
 import X from '../../theme';


### PR DESCRIPTION
- Added missing @commaai/ path to `tipsi-stripe` module (fix for error messages Module `tipsi-stripe` does not exist in the Haste module map)

Also, some notes to get the app working in iOS and Android simulators with macOS Catalina:

- change L104 in `node_modules/@react-native-community/cli/build/commands/runIOS/findMatchingSimulator.js` to fix launching iOS Simulator with latest Xcode (11.4.1):
`-      if (simulator.availability !== '(available)' && simulator.isAvailable !== 'YES') {`
`+      if (!simulator.isAvailable) {`

- in Android simulator, Google authentication did not pass until I commented out Billing in `js/actions/async/Auth.js` L135:
`-  await Billing.configure(accessToken);`
`+  //await Billing.configure(accessToken);`

- run `yarn start` in second terminal before launching `yarn ios` or `yarn android`
