### PR TITLE
health -> pandaState

### DIFF
--- a/js/actions/async/Devices.js
+++ b/js/actions/async/Devices.js
@@ -181,7 +181,7 @@ export function fetchDeviceCarHealth(dongleId) {
     try {
       const resp = await AthenaApi.post(dongleId, {
         method: 'getMessage',
-        params: {'service': 'health', 'timeout': 5000},
+        params: {'service': 'pandaState', 'timeout': 5000},
         jsonrpc: '2.0',
         id: 0,
       })


### PR DESCRIPTION
Service name was changed from health to pandaState in cereal this change reflects that.